### PR TITLE
Dokumentation der FRITZUSER Variable verbessern

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Folgende Variablen müssen angepasst werden:
 | Variable | Erklärung |
 |---|---|
 | `IPS` | IP-Adressen der AVM FRITZ! Geräte. Können mehrere sein, alle Geräte müssen aber das gleiche Passwort haben. |
-| `FRITZUSER` | Username der FRITZ! Weboberfläche. Kann leer gelassen werden, wenn man nur ein Passwort eingeben muss |
+| `FRITZUSER` | Username der FRITZ! Weboberfläche. Es empfiehlt sich einen dedizierten `restart`-Benutzer anzulegen. |
 | `FRITZPW` | Passwort der FRITZ! Weboberfläche. |
 
 Viel Spaß!


### PR DESCRIPTION
Auf meiner FRITZ!Box 5490 mit FRITZ!OS 06.84 funktioniert das Skript ohne Username nicht und ich erhalte eine HTTP 401 Response wie in Issue #2. 

Die Lösung ist ein dedizierter `restart`-Benutzer. Dies hat auch den Vorteil, dass man diesem Benutzer nur die allernötigsten Rechte erteilen muss.